### PR TITLE
Deprecate Legacy Models

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 This plugin allows the AI assistant to search for information from the internet using Perplexity.
 
-**🔑 Perplexity API Key needed**. Click the Settings tab and enter your API Key. Get your Perplexity API Key from [here](https://www.perplexity.ai/settings/api)
+**🔑 Perplexity API Key needed**. Click the Settings tab and enter your API Key. Get your Perplexity API Key from [here](https://www.perplexity.ai/settings/api).
+
+Check out the list of supported models in [Perplexity documentation](https://docs.perplexity.ai/guides/model-cards).
 
 Example usage:
 

--- a/implementation.js
+++ b/implementation.js
@@ -1,6 +1,6 @@
 function search_via_perplexity(params, userSettings) {
   const keyword = params.keyword;
-  const model = userSettings.model || 'llama-3.1-sonar-small-128k-online';
+  const model = userSettings.model || 'sonar';
   const systemMessage = userSettings.systemMessage || 'Be precise and concise.';
   const key = userSettings.apiKey;
 

--- a/plugin.json
+++ b/plugin.json
@@ -15,8 +15,8 @@
     {
       "name": "model",
       "label": "Model",
-      "description": "Optional, default: \"llama-3.1-sonar-small-128k-online\"",
-      "defaultValue": "llama-3.1-sonar-small-128k-online"
+      "description": "Optional, default: \"sonar\"",
+      "defaultValue": "sonar"
     },
     {
       "name": "systemMessage",


### PR DESCRIPTION
According to [this link](https://docs.perplexity.ai/guides/model-cards), legacy models will no longer be available for use after 2/22/2025. This PR changes the default model to "sonar".